### PR TITLE
Add app version to app info panel

### DIFF
--- a/.github/workflows/build_android_apk.yml
+++ b/.github/workflows/build_android_apk.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [devel]
     tags:
-      - 'v**'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches:
       - devel

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,14 @@ except for the additional 'Bugfix' tag.
 
 ## [Unreleased]
 
+## [1.1.1]
+
+### Added
+- App displays the app version in the info panel
+- Clear description for the dotcubeOS version in the info panel
+
+## [1.1.0]
+
 ### Added
 - App from dotcube repo (based on v6.4.3)
 - Docker for local App build with fastlane

--- a/DroneController/app/src/main/java/com/dotscene/dronecontroller/InfoActivity.java
+++ b/DroneController/app/src/main/java/com/dotscene/dronecontroller/InfoActivity.java
@@ -9,6 +9,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
+import com.dotscene.dronecontroller.BuildConfig;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 
@@ -168,7 +169,8 @@ public class InfoActivity extends AppCompatActivity {
 
     adapter.clear();
     adapter.addItem(new InfoItem(getResources().getString(R.string.infoName), info.name));
-    adapter.addItem(new InfoItem(getResources().getString(R.string.infoVersion), version));
+    adapter.addItem(new InfoItem(getResources().getString(R.string.infoAppVersion), BuildConfig.VERSION_NAME));
+    adapter.addItem(new InfoItem(getResources().getString(R.string.infoDotcubeOSVersion), version));
     adapter.addItem(new InfoItem(getResources().getString(R.string.infoHardwareVersion), info.hardwareVersion));
     adapter.addItem(new InfoItem(getResources().getString(R.string.infoNetworkProtocolVersion), "" + ServerStateModel.NETWORK_PROTOCOL_VERSION));
     adapter.addItem(new InfoItem(getResources().getString(R.string.infoNetworkIP), info.usbIpInfo));

--- a/DroneController/app/src/main/res/values-de-rDE/strings.xml
+++ b/DroneController/app/src/main/res/values-de-rDE/strings.xml
@@ -241,7 +241,8 @@
     <string name="help_menu">Hilfe</string>
 
     <string name="infoName"> Name </string>
-    <string name="infoVersion"> Version </string>
+    <string name="infoAppVersion"> App Version </string>
+    <string name="infoDotcubeOSVersion"> dotcubeOS Version </string>
     <string name="infoHardwareVersion"> Hardware Version </string>
     <string name="infoNetworkProtocolVersion"> Netzwerk Protokoll Version </string>
     <string name="infoNetworkIP"> Netzwerk IP </string>

--- a/DroneController/app/src/main/res/values/strings.xml
+++ b/DroneController/app/src/main/res/values/strings.xml
@@ -242,7 +242,8 @@
     <string name="video_path" translatable="false">sdcard/Movies/.manual/video.mp4</string>
 
     <string name="infoName"> Name </string>
-    <string name="infoVersion"> Version </string>
+    <string name="infoAppVersion"> App Version </string>
+    <string name="infoDotcubeOSVersion"> dotcubeOS Version </string>
     <string name="infoHardwareVersion"> Hardware Version </string>
     <string name="infoNetworkProtocolVersion"> Network Protocol Version </string>
     <string name="infoNetworkIP"> Network IP </string>


### PR DESCRIPTION
Adds the app version to the info panel in the app and change the label of the dotcubeOS version to reflect that its for the dotcubeOS.